### PR TITLE
Support for performing incremental legacy key migration. (#10085)

### DIFF
--- a/chia/cmds/keys.py
+++ b/chia/cmds/keys.py
@@ -136,6 +136,14 @@ def verify_cmd(message: str, public_key: str, signature: str):
     verify(message, public_key, signature)
 
 
+@keys_cmd.command("migrate", short_help="Attempt to migrate keys to the Chia keyring")
+@click.pass_context
+def migrate_cmd(ctx: click.Context):
+    from .keys_funcs import migrate_keys
+
+    migrate_keys()
+
+
 @keys_cmd.group("derive", short_help="Derive child keys or wallet addresses")
 @click.option(
     "--fingerprint",

--- a/chia/cmds/keys_funcs.py
+++ b/chia/cmds/keys_funcs.py
@@ -180,6 +180,50 @@ def verify(message: str, public_key: str, signature: str):
     print(AugSchemeMPL.verify(public_key, messageBytes, signature))
 
 
+def migrate_keys():
+    from chia.util.keyring_wrapper import KeyringWrapper
+    from chia.util.misc import prompt_yes_no
+
+    # Check if the keyring needs a full migration (i.e. if it's using the old keyring)
+    if Keychain.needs_migration():
+        KeyringWrapper.get_shared_instance().migrate_legacy_keyring_interactive()
+    else:
+        keys_to_migrate, legacy_keyring = Keychain.get_keys_needing_migration()
+        if len(keys_to_migrate) > 0 and legacy_keyring is not None:
+            print(f"Found {len(keys_to_migrate)} key(s) that need migration:")
+            for key, _ in keys_to_migrate:
+                print(f"Fingerprint: {key.get_g1().get_fingerprint()}")
+
+            print()
+            response = prompt_yes_no("Migrate these keys? (y/n) ")
+            if response:
+                keychain = Keychain()
+                for sk, seed_bytes in keys_to_migrate:
+                    mnemonic = bytes_to_mnemonic(seed_bytes)
+                    keychain.add_private_key(mnemonic, "")
+                    fingerprint = sk.get_g1().get_fingerprint()
+                    print(f"Added private key with public key fingerprint {fingerprint}")
+
+                print(f"Migrated {len(keys_to_migrate)} key(s)")
+
+                print("Verifying migration results...", end="")
+                if Keychain.verify_keys_present(keys_to_migrate):
+                    print(" Verified")
+                    print()
+                    response = prompt_yes_no("Remove key(s) from old keyring? (y/n) ")
+                    if response:
+                        legacy_keyring.delete_keys(keys_to_migrate)
+                        print(f"Removed {len(keys_to_migrate)} key(s) from old keyring")
+                    print("Migration complete")
+                else:
+                    print(" Failed")
+                    sys.exit(1)
+        else:
+            print("No keys need migration")
+
+        Keychain.mark_migration_checked_for_current_version()
+
+
 def _clear_line_part(n: int):
     # Move backward, overwrite with spaces, then move backward again
     sys.stdout.write("\b" * n)

--- a/chia/util/keychain.py
+++ b/chia/util/keychain.py
@@ -235,10 +235,17 @@ class Keychain:
     list of all keys.
     """
 
-    def __init__(self, user: Optional[str] = None, service: Optional[str] = None):
+    def __init__(self, user: Optional[str] = None, service: Optional[str] = None, force_legacy: bool = False):
         self.user = user if user is not None else default_keychain_user()
         self.service = service if service is not None else default_keychain_service()
-        self.keyring_wrapper = KeyringWrapper.get_shared_instance()
+        if force_legacy:
+            legacy_keyring_wrapper = KeyringWrapper.get_legacy_instance()
+            if legacy_keyring_wrapper is not None:
+                self.keyring_wrapper = legacy_keyring_wrapper
+            else:
+                return None
+        else:
+            self.keyring_wrapper = KeyringWrapper.get_shared_instance()
 
     @unlocks_keyring(use_passphrase_cache=True)
     def _get_pk_and_entropy(self, user: str) -> Optional[Tuple[G1Element, bytes]]:
@@ -399,6 +406,27 @@ class Keychain:
             index += 1
             pkent = self._get_pk_and_entropy(get_private_key_user(self.user, index))
 
+    def delete_keys(self, keys_to_delete: List[Tuple[PrivateKey, bytes]]):
+        """
+        Deletes all keys in the list.
+        """
+        remaining_keys = {str(x[0]) for x in keys_to_delete}
+        index = 0
+        pkent = self._get_pk_and_entropy(get_private_key_user(self.user, index))
+        while index <= MAX_KEYS and len(remaining_keys) > 0:
+            if pkent is not None:
+                mnemonic = bytes_to_mnemonic(pkent[1])
+                seed = mnemonic_to_seed(mnemonic, "")
+                sk = AugSchemeMPL.key_gen(seed)
+                sk_str = str(sk)
+                if sk_str in remaining_keys:
+                    self.keyring_wrapper.delete_passphrase(self.service, get_private_key_user(self.user, index))
+                    remaining_keys.remove(sk_str)
+            index += 1
+            pkent = self._get_pk_and_entropy(get_private_key_user(self.user, index))
+        if len(remaining_keys) > 0:
+            raise ValueError(f"{len(remaining_keys)} keys could not be found for deletion")
+
     def delete_all_keys(self):
         """
         Deletes all keys from the keychain.
@@ -463,6 +491,44 @@ class Keychain:
         return KeyringWrapper.get_shared_instance().using_legacy_keyring()
 
     @staticmethod
+    def migration_checked_for_current_version() -> bool:
+        """
+        Returns a bool indicating whether the current client version has checked the legacy keyring
+        for keys needing migration.
+        """
+
+        def compare_versions(version1: str, version2: str) -> int:
+            # Making the assumption that versions will be of the form: x[x].y[y].z[z]
+            # We limit the number of components to 3, with each component being up to 2 digits long
+            ver1: List[int] = [int(n[:2]) for n in version1.split(".")[:3]]
+            ver2: List[int] = [int(n[:2]) for n in version2.split(".")[:3]]
+            if ver1 > ver2:
+                return 1
+            elif ver1 < ver2:
+                return -1
+            else:
+                return 0
+
+        migration_version_file: Path = KeyringWrapper.get_shared_instance().keys_root_path / ".last_legacy_migration"
+        if migration_version_file.exists():
+            current_version_str = pkg_resources.get_distribution("chia-blockchain").version
+            with migration_version_file.open("r") as f:
+                last_migration_version_str = f.read().strip()
+            return compare_versions(current_version_str, last_migration_version_str) <= 0
+
+        return False
+
+    @staticmethod
+    def mark_migration_checked_for_current_version():
+        """
+        Marks the current client version as having checked the legacy keyring for keys needing migration.
+        """
+        migration_version_file: Path = KeyringWrapper.get_shared_instance().keys_root_path / ".last_legacy_migration"
+        current_version_str = pkg_resources.get_distribution("chia-blockchain").version
+        with migration_version_file.open("w") as f:
+            f.write(current_version_str)
+
+    @staticmethod
     def handle_migration_completed():
         """
         When migration completes outside of the current process, we rely on a notification to inform
@@ -492,6 +558,53 @@ class Keychain:
             )
 
         KeyringWrapper.get_shared_instance().migrate_legacy_keyring(cleanup_legacy_keyring=cleanup_legacy_keyring)
+
+    @staticmethod
+    def get_keys_needing_migration() -> Tuple[List[Tuple[PrivateKey, bytes]], Optional["Keychain"]]:
+        legacy_keyring: Optional[Keychain] = Keychain(force_legacy=True)
+        if legacy_keyring is None:
+            return [], None
+        keychain = Keychain()
+        all_legacy_sks = legacy_keyring.get_all_private_keys()
+        all_sks = keychain.get_all_private_keys()
+        set_legacy_sks = {str(x[0]) for x in all_legacy_sks}
+        set_sks = {str(x[0]) for x in all_sks}
+        missing_legacy_keys = set_legacy_sks - set_sks
+        keys_needing_migration = [x for x in all_legacy_sks if str(x[0]) in missing_legacy_keys]
+
+        return keys_needing_migration, legacy_keyring
+
+    @staticmethod
+    def verify_keys_present(keys_to_verify: List[Tuple[PrivateKey, bytes]]) -> bool:
+        """
+        Verifies that the given keys are present in the keychain.
+        """
+        keychain = Keychain()
+        all_sks = keychain.get_all_private_keys()
+        set_sks = {str(x[0]) for x in all_sks}
+        keys_present = set_sks.issuperset(set(map(lambda x: str(x[0]), keys_to_verify)))
+        return keys_present
+
+    @staticmethod
+    def migrate_legacy_keys_silently():
+        """
+        Migrates keys silently, without prompting the user. Requires that keyring.yaml already exists.
+        Does not attempt to delete migrated keys from their old location.
+        """
+        if Keychain.needs_migration():
+            raise RuntimeError("Full keyring migration is required. Cannot run silently.")
+
+        keys_to_migrate, _ = Keychain.get_keys_needing_migration()
+        if len(keys_to_migrate) > 0:
+            keychain = Keychain()
+            for _, seed_bytes in keys_to_migrate:
+                mnemonic = bytes_to_mnemonic(seed_bytes)
+                keychain.add_private_key(mnemonic, "")
+
+            if not Keychain.verify_keys_present(keys_to_migrate):
+                raise RuntimeError("Failed to migrate keys. Legacy keyring left intact.")
+
+        Keychain.mark_migration_checked_for_current_version()
 
     @staticmethod
     def passphrase_is_optional() -> bool:

--- a/tests/core/cmds/test_keys.py
+++ b/tests/core/cmds/test_keys.py
@@ -1,16 +1,20 @@
 import os
+import pkg_resources
 import pytest
 import re
 
+from blspy import PrivateKey
 from chia.cmds.chia import cli
 from chia.cmds.keys import delete_all_cmd, generate_and_print_cmd, show_cmd, sign_cmd, verify_cmd
 from chia.util.config import load_config
-from chia.util.keychain import generate_mnemonic
-from chia.util.keyring_wrapper import KeyringWrapper
+from chia.util.file_keyring import FileKeyring
+from chia.util.keychain import DEFAULT_USER, DEFAULT_SERVICE, Keychain, generate_mnemonic
+from chia.util.keyring_wrapper import DEFAULT_KEYS_ROOT_PATH, KeyringWrapper, LegacyKeyring
 from click.testing import CliRunner, Result
+from keyring.backend import KeyringBackend
 from pathlib import Path
 from tests.util.keyring import TempKeyring
-from typing import Dict
+from typing import Dict, List, Optional, Tuple
 
 
 TEST_MNEMONIC_SEED = (
@@ -19,6 +23,46 @@ TEST_MNEMONIC_SEED = (
     "tomato remind jaguar original blur embody project can"
 )
 TEST_FINGERPRINT = 2877570395
+
+
+class DummyLegacyKeyring(KeyringBackend):
+
+    # Fingerprint 2474840988
+    KEY_0 = (
+        "89e29e5f9c3105b2a853475cab2392468cbfb1d65c3faabea8ebc78fe903fd279e56a8d93f6325fc6c3d833a2ae74832"
+        "b8feaa3d6ee49998f43ce303b66dcc5abb633e5c1d80efe85c40766135e4a44c"
+    )
+
+    # Fingerprint 4149609062
+    KEY_1 = (
+        "8b0d72288727af6238fcd9b0a663cd7d4728738fca597d0046cbb42b6432e0a5ae8026683fc5f9c73df26fb3e1cec2c8"
+        "ad1b4f601107d96a99f6fa9b9d2382918fb1e107fb6655c7bdd8c77c1d9c201f"
+    )
+
+    # Fingerprint 3618811800
+    KEY_2 = (
+        "8b2a26ba319f83bd3da5b1b147a817ecc4ca557f037c9db1cfedc59b16ee6880971b7d292f023358710a292c8db0eb82"
+        "35808f914754ae24e493fad9bc7f654b0f523fb406973af5235256a39bed1283"
+    )
+
+    def __init__(self, populate: bool = True):
+        self.service_dict = {}
+
+        if populate:
+            self.service_dict[DEFAULT_SERVICE] = {
+                f"wallet-{DEFAULT_USER}-0": DummyLegacyKeyring.KEY_0,
+                f"wallet-{DEFAULT_USER}-1": DummyLegacyKeyring.KEY_1,
+                f"wallet-{DEFAULT_USER}-2": DummyLegacyKeyring.KEY_2,
+            }
+
+    def get_password(self, service, username, password=None):
+        return self.service_dict.get(service, {}).get(username)
+
+    def set_password(self, service, username, password):
+        self.service_dict.setdefault(service, {})[username] = password
+
+    def delete_password(self, service, username):
+        del self.service_dict[service][username]
 
 
 class TestKeysCommands:
@@ -40,6 +84,30 @@ class TestKeysCommands:
         with open(seed_file, "w") as f:
             f.write(TEST_MNEMONIC_SEED)
         return seed_file
+
+    @pytest.fixture(scope="function")
+    def setup_keyringwrapper(self, tmp_path):
+        KeyringWrapper.cleanup_shared_instance()
+        KeyringWrapper.set_keys_root_path(tmp_path)
+        _ = KeyringWrapper.get_shared_instance()
+        yield
+        KeyringWrapper.cleanup_shared_instance()
+        KeyringWrapper.set_keys_root_path(DEFAULT_KEYS_ROOT_PATH)
+
+    @pytest.fixture(scope="function")
+    def setup_legacy_keyringwrapper(self, tmp_path, monkeypatch):
+        def mock_setup_keyring_file_watcher(_):
+            pass
+
+        # Silence errors in the watchdog module during testing
+        monkeypatch.setattr(FileKeyring, "setup_keyring_file_watcher", mock_setup_keyring_file_watcher)
+
+        KeyringWrapper.cleanup_shared_instance()
+        KeyringWrapper.set_keys_root_path(tmp_path)
+        KeyringWrapper.get_shared_instance().legacy_keyring = DummyLegacyKeyring()
+        yield
+        KeyringWrapper.cleanup_shared_instance()
+        KeyringWrapper.set_keys_root_path(DEFAULT_KEYS_ROOT_PATH)
 
     def test_generate_with_new_config(self, tmp_path, empty_keyring):
         """
@@ -681,3 +749,224 @@ class TestKeysCommands:
             )
             != -1
         )
+
+    def test_migration_not_needed(self, tmp_path, setup_keyringwrapper, monkeypatch):
+        """
+        Test the `chia keys migrate` command when no migration is necessary
+        """
+
+        def mock_keychain_needs_migration() -> bool:
+            return False
+
+        monkeypatch.setattr(Keychain, "needs_migration", mock_keychain_needs_migration)
+
+        def mock_keychain_get_keys_needing_migration() -> Tuple[List[Tuple[PrivateKey, bytes]], Optional[Keychain]]:
+            return [], None
+
+        monkeypatch.setattr(Keychain, "get_keys_needing_migration", mock_keychain_get_keys_needing_migration)
+
+        runner = CliRunner()
+        result: Result = runner.invoke(
+            cli,
+            [
+                "--root-path",
+                os.fspath(tmp_path),
+                "keys",
+                "migrate",
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert result.output.find("No keys need migration") != -1
+
+    def test_migration_full(self, tmp_path, setup_legacy_keyringwrapper):
+        """
+        Test the `chia keys migrate` command when a full migration is needed
+        """
+
+        legacy_keyring = KeyringWrapper.get_shared_instance().legacy_keyring
+
+        assert legacy_keyring is not None
+        assert len(legacy_keyring.service_dict[DEFAULT_SERVICE]) == 3
+
+        runner = CliRunner()
+        init_result: Result = runner.invoke(
+            cli,
+            ["--root-path", os.fspath(tmp_path), "init"],
+        )
+
+        assert init_result.exit_code == 0
+
+        runner = CliRunner()
+        result: Result = runner.invoke(
+            cli,
+            [
+                "--root-path",
+                os.fspath(tmp_path),
+                "keys",
+                "migrate",
+            ],
+            input="n\ny\ny\n",  # Prompts: 'n' = don't set a passphrase, 'y' = begin migration, 'y' = remove legacy keys
+        )
+
+        assert result.exit_code == 0
+        assert KeyringWrapper.get_shared_instance().using_legacy_keyring() is False  # legacy keyring unset
+        assert type(KeyringWrapper.get_shared_instance().keyring) is FileKeyring  # new keyring set
+        assert len(Keychain().get_all_public_keys()) == 3  # new keyring has 3 keys
+        assert len(legacy_keyring.service_dict[DEFAULT_SERVICE]) == 0  # legacy keys removed
+
+        current_version_str = pkg_resources.get_distribution("chia-blockchain").version
+        last_migration_version_str = (
+            KeyringWrapper.get_shared_instance().keys_root_path / ".last_legacy_migration"
+        ).read_text()
+        assert last_migration_version_str == current_version_str  # last migration version set
+
+    def test_migration_incremental(self, tmp_path, keyring_with_one_key, monkeypatch):
+        KeyringWrapper.set_keys_root_path(tmp_path)
+        KeyringWrapper.cleanup_shared_instance()
+
+        keychain = keyring_with_one_key
+        legacy_keyring = DummyLegacyKeyring()
+
+        def mock_get_legacy_keyring_instance() -> Optional[LegacyKeyring]:
+            nonlocal legacy_keyring
+            return legacy_keyring
+
+        from chia.util import keyring_wrapper
+
+        monkeypatch.setattr(keyring_wrapper, "get_legacy_keyring_instance", mock_get_legacy_keyring_instance)
+
+        assert len(keychain.get_all_private_keys()) == 1
+        assert keychain.keyring_wrapper.legacy_keyring is None
+        assert legacy_keyring is not None
+        assert len(legacy_keyring.service_dict[DEFAULT_SERVICE]) == 3
+
+        runner = CliRunner()
+        init_result: Result = runner.invoke(
+            cli,
+            ["--root-path", os.fspath(tmp_path), "init"],
+        )
+
+        assert init_result.exit_code == 0
+
+        runner = CliRunner()
+        result: Result = runner.invoke(
+            cli,
+            [
+                "--root-path",
+                os.fspath(tmp_path),
+                "keys",
+                "migrate",
+            ],
+            input="y\ny\n",  # Prompts: 'y' = migrate keys, 'y' = remove legacy keys
+        )
+
+        assert result.exit_code == 0
+        assert KeyringWrapper.get_shared_instance().using_legacy_keyring() is False  # legacy keyring is not set
+        assert type(KeyringWrapper.get_shared_instance().keyring) is FileKeyring  # new keyring set
+        assert len(Keychain().get_all_public_keys()) == 4  # new keyring has 4 keys
+        assert len(legacy_keyring.service_dict[DEFAULT_SERVICE]) == 0  # legacy keys removed
+
+        current_version_str = pkg_resources.get_distribution("chia-blockchain").version
+        last_migration_version_str = (
+            KeyringWrapper.get_shared_instance().keys_root_path / ".last_legacy_migration"
+        ).read_text()
+        assert last_migration_version_str == current_version_str  # last migration version set
+
+    def test_migration_silent(self, tmp_path, keyring_with_one_key, monkeypatch):
+        KeyringWrapper.set_keys_root_path(tmp_path)
+        KeyringWrapper.cleanup_shared_instance()
+
+        keychain = keyring_with_one_key
+        legacy_keyring = DummyLegacyKeyring()
+
+        def mock_get_legacy_keyring_instance() -> Optional[LegacyKeyring]:
+            nonlocal legacy_keyring
+            return legacy_keyring
+
+        from chia.util import keyring_wrapper
+
+        monkeypatch.setattr(keyring_wrapper, "get_legacy_keyring_instance", mock_get_legacy_keyring_instance)
+
+        assert len(keychain.get_all_private_keys()) == 1
+        assert len(Keychain().get_all_private_keys()) == 1
+        assert keychain.keyring_wrapper.legacy_keyring is None
+        assert legacy_keyring is not None
+        assert len(legacy_keyring.service_dict[DEFAULT_SERVICE]) == 3
+
+        keys_needing_migration, legacy_migration_keychain = Keychain.get_keys_needing_migration()
+        assert len(keys_needing_migration) == 3
+        assert legacy_migration_keychain is not None
+
+        Keychain.migrate_legacy_keys_silently()
+
+        assert type(KeyringWrapper.get_shared_instance().keyring) is FileKeyring  # new keyring set
+        assert len(Keychain().get_all_public_keys()) == 4  # new keyring has 4 keys
+        assert len(legacy_keyring.service_dict[DEFAULT_SERVICE]) == 3  # legacy keys still intact
+
+    def test_migration_silent_keys_already_present(self, tmp_path, keyring_with_one_key, monkeypatch):
+        KeyringWrapper.set_keys_root_path(tmp_path)
+        KeyringWrapper.cleanup_shared_instance()
+
+        keychain = keyring_with_one_key
+        pkent_str = keychain.keyring_wrapper.get_passphrase(DEFAULT_SERVICE, f"wallet-{DEFAULT_USER}-0")
+        legacy_keyring = DummyLegacyKeyring(populate=False)
+        legacy_keyring.set_password(DEFAULT_SERVICE, f"wallet-{DEFAULT_USER}-0", pkent_str)
+
+        def mock_get_legacy_keyring_instance() -> Optional[LegacyKeyring]:
+            nonlocal legacy_keyring
+            return legacy_keyring
+
+        from chia.util import keyring_wrapper
+
+        monkeypatch.setattr(keyring_wrapper, "get_legacy_keyring_instance", mock_get_legacy_keyring_instance)
+
+        assert len(keychain.get_all_private_keys()) == 1
+        assert len(legacy_keyring.service_dict[DEFAULT_SERVICE]) == 1
+
+        keys_needing_migration, legacy_migration_keychain = Keychain.get_keys_needing_migration()
+        assert len(keys_needing_migration) == 0
+        assert legacy_migration_keychain is not None
+
+        Keychain.migrate_legacy_keys_silently()
+
+        assert type(KeyringWrapper.get_shared_instance().keyring) is FileKeyring  # new keyring set
+        assert len(Keychain().get_all_public_keys()) == 1  # keyring has 1 key
+        assert len(legacy_keyring.service_dict[DEFAULT_SERVICE]) == 1  # legacy keys still intact
+
+    def test_migration_checked(self, tmp_path, monkeypatch):
+        KeyringWrapper.set_keys_root_path(tmp_path)
+        KeyringWrapper.cleanup_shared_instance()
+
+        assert Keychain.migration_checked_for_current_version() is False
+
+        dist_version = ""
+
+        class DummyDistribution:
+            def __init__(self, version):
+                self.version = version
+
+        def mock_get_distribution_version(_) -> DummyDistribution:
+            nonlocal dist_version
+            return DummyDistribution(dist_version)
+
+        monkeypatch.setattr(pkg_resources, "get_distribution", mock_get_distribution_version)
+
+        dist_version = "1.2.11.dev123"
+        assert pkg_resources.get_distribution("chia-blockchain").version == "1.2.11.dev123"
+
+        Keychain.mark_migration_checked_for_current_version()
+
+        last_migration_version_str = (
+            KeyringWrapper.get_shared_instance().keys_root_path / ".last_legacy_migration"
+        ).read_text()
+        assert last_migration_version_str == "1.2.11.dev123"  # last migration version set
+
+        assert Keychain.migration_checked_for_current_version() is True
+
+        dist_version = "1.2.11.dev345"
+        assert Keychain.migration_checked_for_current_version() is True  # We don't check the build number
+        dist_version = "1.2.10.dev111"
+        assert Keychain.migration_checked_for_current_version() is True  # Checked version > current version
+        dist_version = "1.3.0.dev100"
+        assert Keychain.migration_checked_for_current_version() is False  # Checked version < current version


### PR DESCRIPTION
* CLI support for performing an incremental keyring migration. This handles the case where new keys were created by an older client or the light wallet, and those keys then need to be moved to keyring.yaml.

* Opportunistically perform a silent incremental keyring migration when the GUI unlocks the keyring.

Track when keyring migration occurs so that we don't needlessly attempt on each GUI launch. ~/.chia_keys/.last_legacy_migration will contain the app version that last attempted migration.

* Formatting & linter fixes

* Tests for `chia keys migrate`. Missing a test for incremental migration.

* Additional keyring migration tests

* Formatting updates from black in files unrelated to this branch.

* Revert "Formatting updates from black in files unrelated to this branch."

This reverts commit a85030e8e0ea7406683efd8ae41e224c861e08ff.

* Exit loop if remaining_keys <= 0

* Linter fix? Manually making this change as black doesn't identify any issues locally.

* Linter fix again...